### PR TITLE
Add monokai-pro dependency

### DIFF
--- a/neovim.lua
+++ b/neovim.lua
@@ -1,8 +1,12 @@
 return {
 	{
 		"LazyVim/LazyVim",
+		dependencies = {
+			"loctvl842/monokai-pro.nvim",
+		},
 		opts = {
 			colorscheme = "monokai-pro",
 		},
 	},
 }
+


### PR DESCRIPTION
I'm fairly new to nvim and to lazyvim but as best I can tell this theme was failing if one did not already have the `monokai-pro` theme installed (my situation) because `neovim.lua` was not declaring `loctvl842/monokai-pro.nvim` as a dependency.  I added it and this works for me now.

Cheers!
Monokai Forever!